### PR TITLE
OO-37: Add SKOOP as CODEOWNER

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
-* @kartverket/skip
+* @kartverket/skoop
 
-/.security/ @omaen
+/.security/ @okpedersen


### PR DESCRIPTION
- [x] SKOOP must be added as repo admin by someone from @kartverket/skip 